### PR TITLE
Added support to setup encrypted fs without storing the keyfile on remote system.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ v0.3.0
   and fixed the task to allow to disable header backups.
   Only disable header backups when you know what you are doing! [ypid]
 
+- Added support to setup and mount a encrypted filesystem without storing the
+  keyfile on persistent storage of the remote system. [ypid]
+
 v0.2.1
 ------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ v0.3.0
   and fixed the task to allow to disable header backups.
   Only disable header backups when you know what you are doing! [ypid]
 
+- Renamed option ``cryptsetup_keyfile_location`` to
+  ``cryptsetup_secret_location`` as it also contains the header backup on the
+  Ansible controller. [ypid]
+
 - Added support to setup and mount a encrypted filesystem without storing the
   keyfile on persistent storage of the remote system. [ypid]
 
@@ -18,6 +22,10 @@ v0.3.0
 
 - ``cryptsetup_mount_options`` and ``cryptsetup_crypttab_options`` are now
   lists of strings to allow more flexibility. [ypid]
+
+- Added ``cryptsetup_secret_owner``, ``cryptsetup_secret_group`` and
+  ``cryptsetup_secret_mode`` to allow to change file permissions of the secrets
+  directory and files on the Ansible controller. [ypid]
 
 v0.2.1
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ v0.3.0
 - Removed default mount options ``user`` and ``auto`` because they are not good
   defaults for the role. [ypid]
 
+- ``cryptsetup_mount_options`` and ``cryptsetup_crypttab_options`` are now
+  lists of strings to allow more flexibility. [ypid]
+
 v0.2.1
 ------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ v0.3.0
 - Added support to setup and mount a encrypted filesystem without storing the
   keyfile on persistent storage of the remote system. [ypid]
 
+- Removed default mount options ``user`` and ``auto`` because they are not good
+  defaults for the role. [ypid]
+
 v0.2.1
 ------
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ the Ansible controller and the remote system).
 * Create a random keyfile or use an already existing file.
 * Manage `/etc/crypttab` and `/etc/fstab`.
 * Create a LUKS header backup and store it on the Ansible controller.
+* Setup and mount the encrypted filesystem without storing the keyfile on
+  persistent storage of the remote system.
 
 ### Installation
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -144,7 +144,9 @@ cryptsetup_fstype: 'ext4'
 #
 # List of default mount options.
 # Multiple options can be separated by comma.
-cryptsetup_mount_options: 'noatime,nodiratime'
+cryptsetup_mount_options:
+  - 'noatime'
+  - 'nodiratime'
 
 
 # .. envvar:: cryptsetup_state
@@ -170,7 +172,8 @@ cryptsetup_mountpoint_parent_directory: '/media'
 # :file:`/etc/crypttab`. Can be overwritten by ``item.crypttab_options``.
 # Multiple options can be separated by comma.
 # See :manpage:`crypttab(5)` for details.
-cryptsetup_crypttab_options: 'luks'
+cryptsetup_crypttab_options:
+  - 'luks'
 
 # .. envvar:: cryptsetup_hash
 #

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -144,7 +144,7 @@ cryptsetup_fstype: 'ext4'
 #
 # List of default mount options.
 # Multiple options can be separated by comma.
-cryptsetup_mount_options: 'user,auto,noatime,nodiratime'
+cryptsetup_mount_options: 'noatime,nodiratime'
 
 
 # .. envvar:: cryptsetup_state

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,10 +54,36 @@ cryptsetup_host_devices: []
 #   Keyfile settings
 # --------------------
 
-# .. envvar:: cryptsetup_keyfile_location
+# .. envvar:: cryptsetup_secret_path
 #
 # Location where keyfiles are generated and stored on the Ansible controller.
-cryptsetup_keyfile_location: "{{ secret + '/cryptsetup/' + ansible_fqdn }}"
+cryptsetup_secret_path: '{{ secret + "/cryptsetup/" + ansible_fqdn }}'
+
+
+# .. envvar:: cryptsetup_secret_owner
+#
+# System user which owns the secret directory and all files in it on the Ansible controller.
+# You might want to change that if you run this role as root on the Ansible
+# controller itself but the secrets directory is managed by another user.
+# The default is set to the special value ``omit`` to use the owner under which
+# the role is run.
+cryptsetup_secret_owner: '{{ omit }}'
+
+
+# .. envvar:: cryptsetup_secret_group
+#
+# System group of the secret directory and all files in it on the Ansible controller.
+# You might want to change that if you run this role as root on the Ansible
+# controller itself but the secrets directory is managed by another user.
+# The default is set to the special value ``omit`` to use the primary group
+# under which the role is run.
+cryptsetup_secret_group: '{{ omit }}'
+
+
+# .. envvar:: cryptsetup_secret_mode
+#
+# File mode used for the secret directory and all files in it on the Ansible controller.
+cryptsetup_secret_mode: 'u=rwX,g=,o='
 
 
 # .. envvar:: cryptsetup_keyfile_remote_location
@@ -71,19 +97,19 @@ cryptsetup_keyfile_remote_location: '{{ (ansible_local.root.var
 
 # .. envvar:: cryptsetup_keyfile_owner
 #
-# System user which owns the keyfile(s).
+# System user which owns the keyfile(s) on the remote system.
 cryptsetup_keyfile_owner: 'root'
 
 
 # .. envvar:: cryptsetup_keyfile_group
 #
-# System group which owns the keyfile(s).
+# System group of the keyfile(s) on the remote system.
 cryptsetup_keyfile_group: 'root'
 
 
 # .. envvar:: cryptsetup_keyfile_mode
 #
-# File mode used for the keyfile(s).
+# File mode used for the keyfile(s) on the remote system.
 cryptsetup_keyfile_mode: '0600'
 
 

--- a/docs/defaults-configuration.rst
+++ b/docs/defaults-configuration.rst
@@ -105,6 +105,11 @@ you to use more specific parameters which are not documented below.
     devices which have been setup previously and are not available during
     execution of this role.
 
+    Note that if the encrypted filesystem is not mounted when this option is
+    used then this role will not be idempotent because the crypto layer needs
+    to be opened in order to check if the filesystem has been created on top of
+    it.
+
   ``absent``
     Same as ``unmounted`` but additionally removes all configuration, the
     keyfile and the header backup from the remote system for this item.

--- a/docs/defaults-configuration.rst
+++ b/docs/defaults-configuration.rst
@@ -21,8 +21,8 @@ you to use more specific parameters which are not documented below.
   :file:`/dev/sdb5`.
 
 ``crypttab_options``
-  Optional, string. List of options to configure for each device in
-  :file:`/etc/crypttab`.
+  Optional, list of strings. Each string represents an option to configure for
+  each device in :file:`/etc/crypttab`.
   Overwrites the default as configured by ``cryptsetup_crypttab_options``
   variable.
 
@@ -56,7 +56,7 @@ you to use more specific parameters which are not documented below.
     {{ cryptsetup_mountpoint_parent_directory + "/" + item.name }}
 
 ``mount_options``
-  Optional, string. Mount options associated with the filesystem.
+  Optional, list of strings. Mount options associated with the filesystem.
   For more details see :manpage:`mount(8)`.
 
 ``state``
@@ -79,8 +79,8 @@ you to use more specific parameters which are not documented below.
 
     To avoid this, you need to set the following options for the item::
 
-      crypttab_options: 'noauto{{ "" if (cryptsetup_crypttab_options|d("") == "") else ("," + cryptsetup_crypttab_options) }}'
-      mount_options: 'noauto{{ "" if (cryptsetup_mount_options|d("") == "") else ("," + cryptsetup_mount_options) }}'
+      crypttab_options: '{{ ["noauto"] + (cryptsetup_crypttab_options|d([])) }}'
+      mount_options: '{{ ["noauto"] + (cryptsetup_mount_options|d([])) }}'
 
     Note that this option is currently not idempotent because it copes the
     keyfile to the remote system and erases it again.

--- a/docs/defaults-configuration.rst
+++ b/docs/defaults-configuration.rst
@@ -68,6 +68,11 @@ you to use more specific parameters which are not documented below.
     Ensure that the encryption and filesystem layer are in place on the block device and
     the filesystem is mounted.
 
+  ``ansible_controller_mounted``
+    Same as ``mounted`` except that the keyfile is never stored on persistent storage of the remote system.
+    Might be useful when you don’t have a secure place to store the keyfile on the remote system.
+    With this option you will be required to run this role after each reboot to mount the filesystem again.
+
   ``unmounted``
     Ensure that the encryption and filesystem layer are in place on the block device and
     the filesystem is unmounted. Additionally ensures that the cryptsetup mapping

--- a/docs/defaults-configuration.rst
+++ b/docs/defaults-configuration.rst
@@ -73,6 +73,18 @@ you to use more specific parameters which are not documented below.
     Might be useful when you don’t have a secure place to store the keyfile on the remote system.
     With this option you will be required to run this role after each reboot to mount the filesystem again.
 
+    Note that the default is ``auto`` which means that your init system will
+    try to mount the filesystem on boot and might drop you to a root shell if
+    it can’t.
+
+    To avoid this, you need to set the following options for the item::
+
+      crypttab_options: 'noauto{{ "" if (cryptsetup_crypttab_options|d("") == "") else ("," + cryptsetup_crypttab_options) }}'
+      mount_options: 'noauto{{ "" if (cryptsetup_mount_options|d("") == "") else ("," + cryptsetup_mount_options) }}'
+
+    Note that this option is currently not idempotent because it copes the
+    keyfile to the remote system and erases it again.
+
   ``unmounted``
     Ensure that the encryption and filesystem layer are in place on the block device and
     the filesystem is unmounted. Additionally ensures that the cryptsetup mapping

--- a/docs/defaults-configuration.rst
+++ b/docs/defaults-configuration.rst
@@ -79,8 +79,8 @@ you to use more specific parameters which are not documented below.
 
     To avoid this, you need to set the following options for the item::
 
-      crypttab_options: '{{ ["noauto"] + (cryptsetup_crypttab_options|d([])) }}'
-      mount_options: '{{ ["noauto"] + (cryptsetup_mount_options|d([])) }}'
+      crypttab_options: '{{ ["noauto"] + (cryptsetup_crypttab_options|d([]) | list) }}'
+      mount_options: '{{ ["noauto"] + (cryptsetup_mount_options|d([]) | list) }}'
 
     Note that this option is currently not idempotent because it copes the
     keyfile to the remote system and erases it again.

--- a/meta/ansigenome.yml
+++ b/meta/ansigenome.yml
@@ -33,4 +33,5 @@ ansigenome_info:
     * Create a random keyfile or use an already existing file.
     * Manage `/etc/crypttab` and `/etc/fstab`.
     * Create a LUKS header backup and store it on the Ansible controller.
-
+    * Setup and mount the encrypted filesystem without storing the keyfile on
+      persistent storage of the remote system.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -34,5 +34,5 @@ galaxy_info:
     - security
     - filesystem
     - cryptsetup
-    - dm-crypt
+    - dmcrypt
     - luks

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -191,9 +191,9 @@
     opts: '{{ (item.0.crypttab_options | d(cryptsetup_crypttab_options | d(["none"])) ) | list | sort | unique | join(",") }}'
     ## ``none`` is required on Debian jessie by :command:`cryptdisks_start` if no options are given.
     password: '{{ ("/dev/shm"
-              if (item.0.state|d(cryptsetup_state|d("mounted")) == "ansible_controller_mounted")
-              else cryptsetup_keyfile_remote_location)
-              + "/" + item.0.name + "_keyfile.raw" }}'
+                  if (item.0.state|d(cryptsetup_state|d("mounted")) == "ansible_controller_mounted")
+                  else cryptsetup_keyfile_remote_location)
+                  + "/" + item.0.name + "_keyfile.raw" }}'
     path: '{{ item.0.crypttab_path | d(omit) }}'
     state: 'present'
   when: (item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ])
@@ -266,7 +266,7 @@
 
 ## )))
 
-- name: Mount or unmount the plaintext device mapper target
+- name: Handle fstab and mounting of the plaintext device mapper target
   mount:
     src:    '/dev/mapper/{{ item.name }}'
     dump:   '{{ item.mount_dump     | d(omit) }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,14 +14,14 @@
       - item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present', 'absent' ]
       - item.name is defined and item.name is string
       - item.ciphertext_block_device is defined and item.ciphertext_block_device is string
-  with_items: cryptsetup_devices_combined
+  with_items: '{{ cryptsetup_devices_combined }}'
 
 - name: Ensure required packages are installed
   apt:
     name: '{{ item }}'
     state: 'latest'
     install_recommends: False
-  with_flattened: cryptsetup_base_packages
+  with_flattened: '{{ cryptsetup_base_packages }}'
 
 - name: Ensure keyfile and backup directories exist on the remote system
   file:
@@ -46,7 +46,7 @@
   become: False
   delegate_to: 'localhost'
   when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ])
-  with_items: cryptsetup_devices_combined
+  with_items: '{{ cryptsetup_devices_combined }}'
 
 - name: Calculate keyfile creation options
   set_fact:
@@ -60,7 +60,7 @@
   delegate_to: 'localhost'
   register: cryptsetup_register_keyfile_gen
   when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ])
-  with_items: cryptsetup_devices_combined
+  with_items: '{{ cryptsetup_devices_combined }}'
 
 - name: Enforce permissions of the keyfile on the Ansible controller
   tags: [ 'role::cryptsetup:backup' ]
@@ -73,7 +73,7 @@
   delegate_to: 'localhost'
   register: cryptsetup_register_keyfile_gen
   when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ])
-  with_items: cryptsetup_devices_combined
+  with_items: '{{ cryptsetup_devices_combined }}'
 
   ## http://stackoverflow.com/a/28888474
 - name: Test if Ansible is running in check mode
@@ -108,7 +108,7 @@
     src:      '{{ item.keyfile                | d(cryptsetup_secret_path + "/" + item.name + "/keyfile.raw") }}'
     validate: '{{ item.keyfile_validate       | d(omit) }}'
   when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ] and not check_mode)
-  with_items: cryptsetup_devices_combined
+  with_items: '{{ cryptsetup_devices_combined }}'
 
 ## )))
 
@@ -131,14 +131,14 @@
 #     creates: '{{ item.ciphertext_block_device }}{{ item.label_of_first_partition|d("1") }}'
 #     executable: '/bin/bash'
 #   when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'present' ] and item.create_partition_on_block_device|d(False))
-#   with_items: cryptsetup_devices_combined
+#   with_items: '{{ cryptsetup_devices_combined }}'
 
 - name: Check if ciphertext block device exists
   stat:
     path: '{{ item.ciphertext_block_device }}'
   register: cryptsetup_register_ciphertext_device
   when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ])
-  with_items: cryptsetup_devices_combined
+  with_items: '{{ cryptsetup_devices_combined }}'
 
 - name: Fail when ciphertext block device does not exist but the state requires for it to exist
   fail:
@@ -230,7 +230,7 @@
     path: '/dev/mapper/{{ item.name }}'
   register: cryptsetup_register_plaintext_device
   when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ])
-  with_items: cryptsetup_devices_combined
+  with_items: '{{ cryptsetup_devices_combined }}'
 
 - name: Create filesystem on plaintext device mapper target
   filesystem:
@@ -248,7 +248,7 @@
     path: '{{ item.mount | d(cryptsetup_mountpoint_parent_directory + "/" + item.name) }}'
     state: 'directory'
   when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'present' ])
-  with_items: cryptsetup_devices_combined
+  with_items: '{{ cryptsetup_devices_combined }}'
 
 ## )))
 
@@ -303,7 +303,7 @@
     opts:   '{{ (item.mount_options | d(cryptsetup_mount_options | d([]))) | list | sort | unique | join(",") }}'
     passno: '{{ item.mount_passno   | d(omit) }}'
     state:  '{{ "mounted" if (item.state|d(cryptsetup_state) == "ansible_controller_mounted") else item.state|d(cryptsetup_state) }}'
-  with_items: cryptsetup_devices_combined
+  with_items: '{{ cryptsetup_devices_combined }}'
 
 ## Close crypto layer and remove (((
 
@@ -312,7 +312,7 @@
     path: '{{ item.mount | d(cryptsetup_mountpoint_parent_directory + "/" + item.name) }}'
     state: 'absent'
   when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'absent' ])
-  with_items: cryptsetup_devices_combined
+  with_items: '{{ cryptsetup_devices_combined }}'
 
 - name: Stop plaintext device mapper target
   command: cryptdisks_stop "{{ item.0.name }}"
@@ -335,7 +335,7 @@
     path:  '{{ item.crypttab_path | d(omit) }}'
     state: 'absent'
   when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'absent' ])
-  with_items: cryptsetup_devices_combined
+  with_items: '{{ cryptsetup_devices_combined }}'
 
 ## Depending on which filesystem and lower levels the keyfile is stored on, the
 ## ``shred`` operation might be of limited use e.g. because of snapshots or copy-on-write. Try it anyway.
@@ -352,7 +352,7 @@
                  else cryptsetup_keyfile_remote_location)
                  + "/" + item.name + "_keyfile.raw" }}'
   when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'ansible_controller_mounted', 'absent'])
-  with_items: cryptsetup_devices_combined
+  with_items: '{{ cryptsetup_devices_combined }}'
 
 ## Note that there are still two copies of the header on the ciphertext block device
 ## and on the Ansible controller.
@@ -361,7 +361,7 @@
   args:
     removes: '{{ cryptsetup_header_backup_remote_location + "/" + item.name + "_header_backup.raw" }}'
   when: (item.state|d(cryptsetup_state|d('mounted')) == 'absent')
-  with_items: cryptsetup_devices_combined
+  with_items: '{{ cryptsetup_devices_combined }}'
   tags: [ 'role::cryptsetup:backup' ]
 
 ## )))

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -166,8 +166,8 @@
                         else cryptsetup_keyfile_remote_location)
                         + "/" + item.0.name + "_keyfile.raw" }}'
          '{{ item.0.ciphertext_block_device }}'
-  changed_when: ("Command successful." == cryptsetup_register_cmd.stdout)
   register: cryptsetup_register_cmd
+  changed_when: ("Command successful." == cryptsetup_register_cmd.stdout)
   when: (item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ] and item.1.stat.exists)
   with_together:
     - '{{ cryptsetup_devices_combined }}'
@@ -203,8 +203,8 @@
 
 - name: Start plaintext device mapper target
   command: cryptdisks_start "{{ item.0.name }}"
-  changed_when: ("(started)" in cryptsetup_register_cryptdisks_start.stdout)
   register: cryptsetup_register_cryptdisks_start
+  changed_when: ("(started)" in cryptsetup_register_cryptdisks_start.stdout)
   when: (item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ] and item.1.stat.exists)
   with_together:
     - '{{ cryptsetup_devices_combined }}'
@@ -273,7 +273,7 @@
     fstab:  '{{ item.fstab_path     | d(omit) }}'
     fstype: '{{ item.fstype         | d(cryptsetup_fstype) }}'
     name:   '{{ item.mount          | d(cryptsetup_mountpoint_parent_directory + "/" + item.name) }}'
-    opts:   '{{ (item.mount_options | d(cryptsetup_mount_options | d([]))) | list | join(",") }}'
+    opts:   '{{ (item.mount_options | d(cryptsetup_mount_options | d([]))) | list | sort | unique | join(",") }}'
     passno: '{{ item.mount_passno   | d(omit) }}'
     state:  '{{ "mounted" if (item.state|d(cryptsetup_state) == "ansible_controller_mounted") else item.state|d(cryptsetup_state) }}'
   with_items: cryptsetup_devices_combined
@@ -289,12 +289,12 @@
 
 - name: Stop plaintext device mapper target
   command: cryptdisks_stop "{{ item.0.name }}"
+  register: cryptsetup_register_cryptdisks_stop
   changed_when: ("(stopping)" in cryptsetup_register_cryptdisks_stop.stdout)
   failed_when: (
                 cryptsetup_register_cryptdisks_stop.rc != 0 and not
                 ('Stopping crypto disk...' == cryptsetup_register_cryptdisks_stop.stdout and cryptsetup_register_cryptdisks_stop.rc == 1)
                )
-  register: cryptsetup_register_cryptdisks_stop
   when: (item.0.state|d(cryptsetup_state|d('mounted')) in [ 'unmounted', 'absent' ] or
           (item.0.state|d(cryptsetup_state|d('mounted')) in [ 'present' ] and item.1|changed)
         )

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -188,7 +188,7 @@
   crypttab:
     backing_device: '{{ ("UUID=" + item.1.stdout) if (item.1.stdout|d() and item.0.use_uuid|d(cryptsetup_use_uuid)|bool) else item.0.ciphertext_block_device }}'
     name: '{{ item.0.name }}'
-    opts: '{{ item.0.crypttab_options | d(cryptsetup_crypttab_options | d("none")) }}'
+    opts: '{{ (item.0.crypttab_options | d(cryptsetup_crypttab_options | d(["none"]))) | list | join(",") }}'
     ## ``none`` is required on Debian jessie by :command:`cryptdisks_start` if no options are given.
     password: '{{ ("/dev/shm"
               if (item.0.state|d(cryptsetup_state|d("mounted")) == "ansible_controller_mounted")
@@ -269,12 +269,12 @@
 - name: Mount or unmount the plaintext device mapper target
   mount:
     src:    '/dev/mapper/{{ item.name }}'
-    dump:   '{{ item.mount_dump    | d(omit) }}'
-    fstab:  '{{ item.fstab_path    | d(omit) }}'
-    fstype: '{{ item.fstype        | d(cryptsetup_fstype) }}'
-    name:   '{{ item.mount         | d(cryptsetup_mountpoint_parent_directory + "/" + item.name) }}'
-    opts:   '{{ item.mount_options | d(cryptsetup_mount_options | d(omit)) }}'
-    passno: '{{ item.mount_passno  | d(omit) }}'
+    dump:   '{{ item.mount_dump     | d(omit) }}'
+    fstab:  '{{ item.fstab_path     | d(omit) }}'
+    fstype: '{{ item.fstype         | d(cryptsetup_fstype) }}'
+    name:   '{{ item.mount          | d(cryptsetup_mountpoint_parent_directory + "/" + item.name) }}'
+    opts:   '{{ (item.mount_options | d(cryptsetup_mount_options | d([]))) | list | join(",") }}'
+    passno: '{{ item.mount_passno   | d(omit) }}'
     state:  '{{ "mounted" if (item.state|d(cryptsetup_state) == "ansible_controller_mounted") else item.state|d(cryptsetup_state) }}'
   with_items: cryptsetup_devices_combined
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -188,7 +188,7 @@
   crypttab:
     backing_device: '{{ ("UUID=" + item.1.stdout) if (item.1.stdout|d() and item.0.use_uuid|d(cryptsetup_use_uuid)|bool) else item.0.ciphertext_block_device }}'
     name: '{{ item.0.name }}'
-    opts: '{{ (item.0.crypttab_options | d(cryptsetup_crypttab_options | d(["none"]))) | list | join(",") }}'
+    opts: '{{ (item.0.crypttab_options | d(cryptsetup_crypttab_options | d(["none"])) ) | list | sort | unique | join(",") }}'
     ## ``none`` is required on Debian jessie by :command:`cryptdisks_start` if no options are given.
     password: '{{ ("/dev/shm"
               if (item.0.state|d(cryptsetup_state|d("mounted")) == "ansible_controller_mounted")

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -161,11 +161,11 @@
          {% if cryptsetup_use_random|d("default") != "default" %}
          {{ "--use-random" if cryptsetup_use_random|d() else "--use-urandom" }}
          {% endif %}
-         --key-file '{{ cryptsetup_keyfile_remote_location + "/" + item.0.name + "_keyfile.raw" }}'
-         '{{ ("/dev/shm"
-            if (item.0.state|d(cryptsetup_state|d("mounted")) == "ansible_controller_mounted")
-            else cryptsetup_keyfile_remote_location)
-            + "/" + item.0.name + "_keyfile.raw" }}'
+         --key-file '{{ ("/dev/shm"
+                        if (item.0.state|d(cryptsetup_state|d("mounted")) == "ansible_controller_mounted")
+                        else cryptsetup_keyfile_remote_location)
+                        + "/" + item.0.name + "_keyfile.raw" }}'
+         '{{ item.0.ciphertext_block_device }}'
   changed_when: ("Command successful." == cryptsetup_register_cmd.stdout)
   register: cryptsetup_register_cmd
   when: (item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ] and item.1.stat.exists)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,9 +38,11 @@
 
 - name: Create secrets directory on Ansible controller
   file:
-    path: '{{ cryptsetup_keyfile_location + "/" + item.name }}'
+    path:  '{{ cryptsetup_secret_path + "/" + item.name }}'
     state: 'directory'
-    mode: '0750'
+    owner: '{{ cryptsetup_secret_owner }}'
+    group: '{{ cryptsetup_secret_group }}'
+    mode:  '{{ cryptsetup_secret_mode }}'
   become: False
   delegate_to: 'localhost'
   when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ])
@@ -50,10 +52,23 @@
   set_fact:
     cryptsetup_dd_bs: '{{ ((512/8) if cryptsetup_key_size|d() == "default" else ((cryptsetup_key_size)/8)) | int }}'
 
-- name: Generate keyfile on Ansible controller
-  command: dd if=/dev/random of='{{ item.keyfile | d(cryptsetup_keyfile_location + "/" + item.name + "/keyfile.raw") }}' bs={{ cryptsetup_dd_bs }} count=1 iflag=fullblock
+- name: Generate keyfile on the Ansible controller
+  command: dd if=/dev/random of='{{ item.keyfile | d(cryptsetup_secret_path + "/" + item.name + "/keyfile.raw") }}' bs={{ cryptsetup_dd_bs }} count=1 iflag=fullblock
   args:
-    creates: '{{ item.keyfile | d(cryptsetup_keyfile_location + "/" + item.name + "/keyfile.raw") }}'
+    creates: '{{ item.keyfile | d(cryptsetup_secret_path + "/" + item.name + "/keyfile.raw") }}'
+  become: False
+  delegate_to: 'localhost'
+  register: cryptsetup_register_keyfile_gen
+  when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ])
+  with_items: cryptsetup_devices_combined
+
+- name: Enforce permissions of the keyfile on the Ansible controller
+  tags: [ 'role::cryptsetup:backup' ]
+  file:
+    path:  '{{ item.keyfile | d(cryptsetup_secret_path + "/" + item.name + "/keyfile.raw") }}'
+    owner: '{{ cryptsetup_secret_owner }}'
+    group: '{{ cryptsetup_secret_group }}'
+    mode:  '{{ cryptsetup_secret_mode }}'
   become: False
   delegate_to: 'localhost'
   register: cryptsetup_register_keyfile_gen
@@ -90,7 +105,7 @@
     serole:   '{{ item.keyfile_serole         | d(omit) }}'
     setype:   '{{ item.keyfile_setype         | d(omit) }}'
     seuser:   '{{ item.keyfile_seuser         | d(omit) }}'
-    src:      '{{ item.keyfile                | d(cryptsetup_keyfile_location + "/" + item.name + "/keyfile.raw") }}'
+    src:      '{{ item.keyfile                | d(cryptsetup_secret_path + "/" + item.name + "/keyfile.raw") }}'
     validate: '{{ item.keyfile_validate       | d(omit) }}'
   when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ] and not check_mode)
   with_items: cryptsetup_devices_combined
@@ -146,7 +161,7 @@
 ## does not work because Ansible/Python tries to decode the random bytes as UTF-8.
 ## Issue: https://github.com/ansible/ansible/issues/7957
 # - name: Read the content of the keyfile and encoding it using base64
-#   command: base64 '{{ item.0.keyfile | d(cryptsetup_keyfile_location + "/" + item.0.name + "/keyfile.raw") }}'
+#   command: base64 '{{ item.0.keyfile | d(cryptsetup_secret_path + "/" + item.0.name + "/keyfile.raw") }}'
 #   register: cryptsetup_register_keyfile_b64encode
 #   become: False
 #   delegate_to: 'localhost'
@@ -255,10 +270,22 @@
 - name: Store the header backup in secret directory on to the Ansible controller
   tags: [ 'role::cryptsetup:backup' ]
   fetch:
-    src: '{{ cryptsetup_header_backup_remote_location + "/" + item.0.name + "_header_backup.raw" }}'
-    dest: '{{ cryptsetup_keyfile_location + "/" + item.0.name }}/header_backup.raw'
+    src:  '{{ cryptsetup_header_backup_remote_location + "/" + item.0.name + "_header_backup.raw" }}'
+    dest: '{{ cryptsetup_secret_path + "/" + item.0.name + "/header_backup.raw" }}'
     fail_on_missing: True
     flat: True
+  when: ((cryptsetup_header_backup|d() | bool) and item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ] and item.1.stat.exists)
+  with_together:
+    - '{{ cryptsetup_devices_combined }}'
+    - '{{ cryptsetup_register_ciphertext_device.results|d([]) }}'
+
+- name: Enforce permissions of the header backup in secret directory on the Ansible controller
+  tags: [ 'role::cryptsetup:backup' ]
+  file:
+    path:  '{{ cryptsetup_secret_path + "/" + item.0.name + "/header_backup.raw" }}'
+    owner: '{{ cryptsetup_secret_owner }}'
+    group: '{{ cryptsetup_secret_group }}'
+    mode:  '{{ cryptsetup_secret_mode }}'
   when: ((cryptsetup_header_backup|d() | bool) and item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ] and item.1.stat.exists)
   with_together:
     - '{{ cryptsetup_devices_combined }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,9 +3,9 @@
 - name: Combine cryptsetup device lists
   set_fact:
     cryptsetup_devices_combined: '{{
-      (cryptsetup_devices|d([]) | list) +
-      (cryptsetup_group_devices|d([]) | list) +
-      (cryptsetup_host_devices|d([]) | list) }}'
+      (cryptsetup_devices       | d([]) | list) +
+      (cryptsetup_group_devices | d([]) | list) +
+      (cryptsetup_host_devices  | d([]) | list) }}'
   tags: [ 'role::cryptsetup:backup' ]
 
 - name: Ensure that required options are specified and valid for each given device

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: Ensure that required options are specified and valid for each given device
   assert:
     that:
-      - item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'unmounted', 'present', 'absent' ]
+      - item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present', 'absent' ]
       - item.name is defined and item.name is string
       - item.ciphertext_block_device is defined and item.ciphertext_block_device is string
   with_items: cryptsetup_devices_combined
@@ -43,7 +43,7 @@
     mode: '0750'
   become: False
   delegate_to: 'localhost'
-  when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'unmounted', 'present' ])
+  when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ])
   with_items: cryptsetup_devices_combined
 
 - name: Calculate keyfile creation options
@@ -57,7 +57,7 @@
   become: False
   delegate_to: 'localhost'
   register: cryptsetup_register_keyfile_gen
-  when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'unmounted', 'present' ])
+  when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ])
   with_items: cryptsetup_devices_combined
 
   ## http://stackoverflow.com/a/28888474
@@ -69,9 +69,17 @@
 - name: Save fact if Ansible is running in check mode in variable
   set_fact: check_mode={{ cryptsetup_register_check_mode|skipped }}
 
+- name: Ensure that /dev/shm/ is stored in RAM (assumed to be non-persistent)
+  ## Also assuming that the keyfile is not swapped out in the short time it is going to exist in tmpfs.
+  command: df /dev/shm --type tmpfs
+  changed_when: False
+
 - name: Copy keyfiles to remote system
   copy:
-    dest:     '{{ cryptsetup_keyfile_remote_location + "/" + item.name + "_keyfile.raw" }}'
+    dest: '{{ ("/dev/shm"
+              if (item.state|d(cryptsetup_state|d("mounted")) == "ansible_controller_mounted")
+              else cryptsetup_keyfile_remote_location)
+              + "/" + item.name + "_keyfile.raw" }}'
     backup:   '{{ item.keyfile_backup         | d(omit) }}'
     follow:   '{{ item.keyfile_follow         | d(omit) }}'
     force:    '{{ item.keyfile_force          | d(omit) }}'
@@ -84,7 +92,7 @@
     seuser:   '{{ item.keyfile_seuser         | d(omit) }}'
     src:      '{{ item.keyfile                | d(cryptsetup_keyfile_location + "/" + item.name + "/keyfile.raw") }}'
     validate: '{{ item.keyfile_validate       | d(omit) }}'
-  when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'unmounted', 'present' ] and not check_mode)
+  when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ] and not check_mode)
   with_items: cryptsetup_devices_combined
 
 ## )))
@@ -107,32 +115,41 @@
 #   args:
 #     creates: '{{ item.ciphertext_block_device }}{{ item.label_of_first_partition|d("1") }}'
 #     executable: '/bin/bash'
-#   when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'present' ] and item.create_partition_on_block_device|d(False))
+#   when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'present' ] and item.create_partition_on_block_device|d(False))
 #   with_items: cryptsetup_devices_combined
 
 - name: Check if ciphertext block device exists
   stat:
     path: '{{ item.ciphertext_block_device }}'
   register: cryptsetup_register_ciphertext_device
-  when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'unmounted', 'present' ])
+  when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ])
   with_items: cryptsetup_devices_combined
 
 - name: Fail when ciphertext block device does not exist but the state requires for it to exist
   fail:
     msg: 'Ciphertext block device {{ item.0.ciphertext_block_device }} does not exist and state was requested to be {{ item.0.state|d(cryptsetup_state|d("mounted")) }}!'
-  when: (item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'unmounted' ] and not item.1.stat.exists)
+  when: (item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted' ] and not item.1.stat.exists)
   with_together:
     - '{{ cryptsetup_devices_combined }}'
     - '{{ cryptsetup_register_ciphertext_device.results|d([]) }}'
 
 - name: Fail when ciphertext block device does not exist but the keyfile has changed
   fail:
-    msg: 'Ciphertext block device {{ item.0.ciphertext_block_device }} does not exist but the keyfile has just been generated. You will need to make the block device available during a following Ansible run so that the encryption and filesystem layer can be setup. You will not see this error on following runs but that does not mean that the encryption and filesystem setup was successfully until you make the block device available. See documentation for details.'
-  when: (item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'unmounted', 'present' ] and not item.1.stat.exists and item.2|changed)
+    msg: 'Ciphertext block device {{ item.0.ciphertext_block_device }} does not exist but the keyfile has just been generated. You will need to make the block device available during a later Ansible run so that the encryption and filesystem layer can be setup. You will not see this error on later runs but that does not mean that the encryption and filesystem setup was successfully until you make the block device available. See documentation for details.'
+  when: (item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ] and not item.1.stat.exists and item.2|changed)
   with_together:
     - '{{ cryptsetup_devices_combined }}'
     - '{{ cryptsetup_register_ciphertext_device.results|d([]) }}'
     - '{{ cryptsetup_register_keyfile_gen.results|d([]) }}'
+
+## Using {{ lookup("file", item.0.keyfile|d(…)) | b64encode }}
+## does not work because Ansible/Python tries to decode the random bytes as UTF-8.
+## Issue: https://github.com/ansible/ansible/issues/7957
+# - name: Read the content of the keyfile and encoding it using base64
+#   command: base64 '{{ item.0.keyfile | d(cryptsetup_keyfile_location + "/" + item.0.name + "/keyfile.raw") }}'
+#   register: cryptsetup_register_keyfile_b64encode
+#   become: False
+#   delegate_to: 'localhost'
 
 - name: Create encryption layer
   shell: cryptsetup isLuks "{{ item.0.ciphertext_block_device }}" || cryptsetup luksFormat
@@ -142,17 +159,16 @@
          {{ "" if cryptsetup_key_size|d() == "default" else ("--key-size=" + cryptsetup_key_size|string) }}
          {{ "" if cryptsetup_iter_time|d() == "default" else ("--iter-time=" + cryptsetup_iter_time|string) }}
          {% if cryptsetup_use_random|d("default") != "default" %}
-         {% if cryptsetup_use_random|d() %}
-         --use-random
-         {% else %}
-         --use-urandom
+         {{ "--use-random" if cryptsetup_use_random|d() else "--use-urandom" }}
          {% endif %}
-         {% endif %}
-         --key-file "{{ cryptsetup_keyfile_remote_location + "/" + item.0.name + "_keyfile.raw" }}"
-         "{{ item.0.ciphertext_block_device }}"
+         --key-file '{{ cryptsetup_keyfile_remote_location + "/" + item.0.name + "_keyfile.raw" }}'
+         '{{ ("/dev/shm"
+            if (item.0.state|d(cryptsetup_state|d("mounted")) == "ansible_controller_mounted")
+            else cryptsetup_keyfile_remote_location)
+            + "/" + item.0.name + "_keyfile.raw" }}'
   changed_when: ("Command successful." == cryptsetup_register_cmd.stdout)
   register: cryptsetup_register_cmd
-  when: (item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'unmounted', 'present' ] and item.1.stat.exists)
+  when: (item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ] and item.1.stat.exists)
   with_together:
     - '{{ cryptsetup_devices_combined }}'
     - '{{ cryptsetup_register_ciphertext_device.results|d([]) }}'
@@ -163,7 +179,7 @@
   changed_when: False
   failed_when: (cryptsetup_register_ciphertext_blkid.rc not in [ 0, 2 ])
   always_run: True
-  when: (item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'unmounted', 'present' ] and item.1.stat.exists)
+  when: (item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ] and item.1.stat.exists)
   with_together:
     - '{{ cryptsetup_devices_combined }}'
     - '{{ cryptsetup_register_ciphertext_device.results|d([]) }}'
@@ -174,10 +190,13 @@
     name: '{{ item.0.name }}'
     opts: '{{ item.0.crypttab_options | d(cryptsetup_crypttab_options | d("none")) }}'
     ## ``none`` is required on Debian jessie by :command:`cryptdisks_start` if no options are given.
-    password: '{{ cryptsetup_keyfile_remote_location + "/" + item.0.name + "_keyfile.raw" }}'
+    password: '{{ ("/dev/shm"
+              if (item.0.state|d(cryptsetup_state|d("mounted")) == "ansible_controller_mounted")
+              else cryptsetup_keyfile_remote_location)
+              + "/" + item.0.name + "_keyfile.raw" }}'
     path: '{{ item.0.crypttab_path | d(omit) }}'
     state: 'present'
-  when: (item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'unmounted', 'present' ])
+  when: (item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ])
   with_together:
     - '{{ cryptsetup_devices_combined }}'
     - '{{ cryptsetup_register_ciphertext_blkid.results|d([]) }}'
@@ -186,7 +205,7 @@
   command: cryptdisks_start "{{ item.0.name }}"
   changed_when: ("(started)" in cryptsetup_register_cryptdisks_start.stdout)
   register: cryptsetup_register_cryptdisks_start
-  when: (item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'unmounted', 'present' ] and item.1.stat.exists)
+  when: (item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ] and item.1.stat.exists)
   with_together:
     - '{{ cryptsetup_devices_combined }}'
     - '{{ cryptsetup_register_ciphertext_device.results|d([]) }}'
@@ -195,7 +214,7 @@
   stat:
     path: '/dev/mapper/{{ item.name }}'
   register: cryptsetup_register_plaintext_device
-  when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'unmounted', 'present' ])
+  when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ])
   with_items: cryptsetup_devices_combined
 
 - name: Create filesystem on plaintext device mapper target
@@ -228,7 +247,7 @@
     rm -f "{{ cryptsetup_header_backup_remote_location + "/" + item.0.name + "_header_backup.raw" }}"
     cryptsetup luksHeaderBackup "{{ item.0.ciphertext_block_device }}" --header-backup-file "{{ cryptsetup_header_backup_remote_location + "/" + item.0.name + "_header_backup.raw" }}"
   changed_when: False
-  when: ((cryptsetup_header_backup|d() | bool) and item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'unmounted', 'present' ] and item.1.stat.exists)
+  when: ((cryptsetup_header_backup|d() | bool) and item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ] and item.1.stat.exists)
   with_together:
     - '{{ cryptsetup_devices_combined }}'
     - '{{ cryptsetup_register_ciphertext_device.results|d([]) }}'
@@ -240,7 +259,7 @@
     dest: '{{ cryptsetup_keyfile_location + "/" + item.0.name }}/header_backup.raw'
     fail_on_missing: True
     flat: True
-  when: ((cryptsetup_header_backup|d() | bool) and item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'unmounted', 'present' ] and item.1.stat.exists)
+  when: ((cryptsetup_header_backup|d() | bool) and item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ] and item.1.stat.exists)
   with_together:
     - '{{ cryptsetup_devices_combined }}'
     - '{{ cryptsetup_register_ciphertext_device.results|d([]) }}'
@@ -256,7 +275,7 @@
     name:   '{{ item.mount         | d(cryptsetup_mountpoint_parent_directory + "/" + item.name) }}'
     opts:   '{{ item.mount_options | d(cryptsetup_mount_options | d(omit)) }}'
     passno: '{{ item.mount_passno  | d(omit) }}'
-    state:  '{{ item.state         | d(cryptsetup_state) }}'
+    state:  '{{ "mounted" if (item.state|d(cryptsetup_state) == "ansible_controller_mounted") else item.state|d(cryptsetup_state) }}'
   with_items: cryptsetup_devices_combined
 
 ## Close crypto layer and remove (((
@@ -295,10 +314,17 @@
 ## ``shred`` operation might be of limited use e.g. because of snapshots or copy-on-write. Try it anyway.
 ## Note that there is still at least one copy of the keyfile on the Ansible controller.
 - name: Ensure keyfile is unaccessible on the remote system
-  command: shred --remove --zero --iterations=42 "{{ cryptsetup_keyfile_remote_location + "/" + item.name + "_keyfile.raw" }}"
+  command: shred --remove --zero --iterations=42
+           '{{ ("/dev/shm"
+              if (item.state|d(cryptsetup_state|d("mounted")) == "ansible_controller_mounted")
+              else cryptsetup_keyfile_remote_location)
+              + "/" + item.name + "_keyfile.raw" }}'
   args:
-    removes: '{{ cryptsetup_keyfile_remote_location + "/" + item.name + "_keyfile.raw" }}'
-  when: (item.state|d(cryptsetup_state|d('mounted')) == 'absent')
+    removes: '{{ ("/dev/shm"
+                 if (item.state|d(cryptsetup_state|d("mounted")) == "ansible_controller_mounted")
+                 else cryptsetup_keyfile_remote_location)
+                 + "/" + item.name + "_keyfile.raw" }}'
+  when: (item.state|d(cryptsetup_state|d('mounted')) in [ 'ansible_controller_mounted', 'absent'])
   with_items: cryptsetup_devices_combined
 
 ## Note that there are still two copies of the header on the ciphertext block device


### PR DESCRIPTION
Added support to setup and mount a encrypted filesystem without storing the keyfile on persistent storage of the remote system.

@drybjed Thanks for the nice idea :wink:

Edit: I will leave this PR open for a while to test the role in some more real world use cases before merging.