### PR TITLE
fix checking for header backup on the controller

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -286,6 +286,8 @@
     owner: '{{ cryptsetup_secret_owner }}'
     group: '{{ cryptsetup_secret_group }}'
     mode:  '{{ cryptsetup_secret_mode }}'
+  become: False
+  delegate_to: 'localhost'
   when: ((item.backup_header|d(cryptsetup_header_backup) | bool) and item.0.state|d(cryptsetup_state|d('mounted')) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ] and item.1.stat.exists)
   with_together:
     - '{{ cryptsetup_devices_combined }}'


### PR DESCRIPTION
Looks like there's a small bug in 0.3.0 -- "Enforce permissions of the header backup in secret directory on the Ansible controller" runs on the agent instead of the controller.