### PR TITLE
Terminate role execution if a vulnerable Ansible version is used

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,15 @@ The current role maintainer_ is ypid_.
 
 .. _debops.cryptsetup master: https://github.com/debops/ansible-owncloud/compare/v0.4.0...master
 
+Changed
+~~~~~~~
+
+- Terminate role execution if a vulnerable Ansible version is used to run the
+  role as `CVE-2016-8628 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-8628>`_
+  violates one of the design goals of the role.
+  The minimum Ansible version without known vulnerabilities is Ansible 2.1.3.
+  Refer to `Ansible Security`_ for details. [ypid_]
+
 
 `debops.cryptsetup v0.4.0`_ - 2016-10-23
 ----------------------------------------

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ filesystem (both on the Ansible controller and the remote system).
 
 ### Installation
 
-This role requires at least Ansible `v1.9.0`. To install it, run:
+This role requires at least Ansible `v2.1.3`. To install it, run:
 
 ```Shell
 ansible-galaxy install debops.cryptsetup

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -25,7 +25,7 @@ Features
 Installation
 ~~~~~~~~~~~~
 
-This role requires at least Ansible ``v1.9.0``. To install it, run::
+This role requires at least Ansible ``v2.1.3``. To install it, run::
 
     ansible-galaxy install debops.cryptsetup
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
   author: 'Robin Schneider'
   description: 'Setup and manage encrypted filesystems'
   license: 'GPL-3.0'
-  min_ansible_version: '1.9.0'
+  min_ansible_version: '2.1.3'
 
   platforms:
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,11 @@
 
 ## Preparation and error checking (((
 
+- name: Check for Ansible version without known vulnerabilities
+  assert:
+    that: 'ansible_version.full | version_compare("2.1.3.0", ">=")'
+    msg: 'VULNERABLE Ansible version DETECTED, please update to Ansible v2.1.3 or newer! Exiting.'
+
   ## https://stackoverflow.com/a/28888474
 - name: Test if Ansible is running in check mode
   command: /bin/true


### PR DESCRIPTION
Related to: https://github.com/ansible/ansible/issues/18375
Follows example: https://github.com/nusenu/ansible-relayor/issues/82

PS: I would propose this assertion for other sensitive roles too. Like
debops.pki for example. Running such roles with a Ansible version with
unpatched CVE-2016-8628 violates the design goals of such roles.