### PR TITLE
always_run is deprecated. Use check_mode = no instead..

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,11 @@ The current role maintainer_ is ypid_.
 
 .. _debops.cryptsetup master: https://github.com/debops/ansible-cryptsetup/compare/v0.5.1...master
 
+Fixed
+~~~~~
+
+- Fix Ansible 2.2 deprecation warnings. [brzhk]
+
 
 `debops.cryptsetup v0.5.1`_ - 2017-05-08
 ----------------------------------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
   author: 'Robin Schneider'
   description: 'Setup and manage encrypted filesystems'
   license: 'GPL-3.0'
-  min_ansible_version: '2.1.4'
+  min_ansible_version: '2.2.0'
 
   platforms:
 

--- a/tasks/manage_devices.yml
+++ b/tasks/manage_devices.yml
@@ -175,7 +175,7 @@
   register: cryptsetup__register_ciphertext_blkid
   changed_when: False
   failed_when: (cryptsetup__register_ciphertext_blkid.rc not in [ 0, 2 ])
-  check_mode: no
+  check_mode: False
   when: (item.0.state|d(cryptsetup__state) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ] and item.1.stat.exists)
   with_together:
     - '{{ cryptsetup__process_devices|d([]) }}'

--- a/tasks/manage_devices.yml
+++ b/tasks/manage_devices.yml
@@ -175,7 +175,7 @@
   register: cryptsetup__register_ciphertext_blkid
   changed_when: False
   failed_when: (cryptsetup__register_ciphertext_blkid.rc not in [ 0, 2 ])
-  always_run: True
+  check_mode: no
   when: (item.0.state|d(cryptsetup__state) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ] and item.1.stat.exists)
   with_together:
     - '{{ cryptsetup__process_devices|d([]) }}'


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.