### PR TITLE
Prevent keyfiles content from being displayed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,8 @@ Fixed
 
 - The role now requires at least Ansible v2.2 due to use of the ``check_mode:
   False`` directive. [brzhk]
+- Prevent keyfiles content from being displayed when the ``--diff`` Ansible command line option
+  is used. [jpiron]
 
 Security
 ~~~~~~~~

--- a/tasks/manage_devices.yml
+++ b/tasks/manage_devices.yml
@@ -89,6 +89,7 @@
   when: (item.state|d(cryptsetup__state) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ]
          and not ansible_check_mode and 'remote_keyfile' not in item)
   with_items: '{{ cryptsetup__process_devices|d([]) }}'
+  no_log: True
 
 ## ]]]
 


### PR DESCRIPTION
The copy module will display the content of the keyfiles if used with the
--diff command line option.