### PR TITLE
Fix secrets directories creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,10 @@ Fixed
 
 - Don’t upgrade :envvar:`cryptsetup__base_packages`, only ensure that they are installed. [ypid_]
 
+- Fix secrets directories creation which was ignoring
+  :ref:`item.remote_keyfile <cryptsetup__devices_remote_keyfile>` and occuring only when
+  :ref:`item.mode <cryptsetup_devices_mode>` was set to ``luks``. [jpiron, ypid_]
+
 Security
 ~~~~~~~~
 

--- a/tasks/manage_devices.yml
+++ b/tasks/manage_devices.yml
@@ -27,7 +27,7 @@
   become: False
   delegate_to: 'localhost'
   when: (item.state|d(cryptsetup__state) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ]
-         and (item.mode|d("luks") == "luks" or 'remote_keyfile' not in item))
+         and 'remote_keyfile' not in item)
   with_items: '{{ cryptsetup__process_devices|d([]) }}'
 ## ]]]
 


### PR DESCRIPTION
It's my understanding that secrets directories should not be created when item.remote_keyfile is defined.